### PR TITLE
fix: update js-yaml to 4.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "clsx": "2.1.1",
     "framer-motion": "11.15.0",
     "js-base64": "^3.7.8",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.1",
     "json5": "^2.2.3",
     "jsonrepair": "^3.14.0",
     "jsonwebtoken": "8.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^3.7.8
         version: 3.7.8
       js-yaml:
-        specifier: ^4.1.1
-        version: 4.1.1
+        specifier: ^4.3.1
+        version: 4.3.1
       json5:
         specifier: ^2.2.3
         version: 2.2.3
@@ -4819,8 +4819,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsep@1.4.0:
@@ -7825,7 +7825,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -11548,7 +11548,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.6.3
@@ -12103,7 +12103,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -12889,7 +12889,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## Summary

Update js-yaml from 4.1.1 to 4.3.1 and refresh the pnpm lockfile.

## Why

js-yaml 4.x before 4.3.1 is affected by the quadratic `!!omap` resolution issue described in [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj), which tracks the missing backport of the CVE-2026-59870 fix. The data format converter directly passes user-provided YAML to `YAML.load()`.

## Impact

This is a patch-level dependency update with no application source changes.

## Validation

- `pnpm@9.12.2 install --lockfile-only --frozen-lockfile --ignore-scripts`
- parsed representative YAML with js-yaml 4.3.1
- verified the lockfile contains 4.3.1 and no 4.1.1 entry
- `git diff --check`

Full dependency installation and the full build were intentionally skipped because this repository has a large dependency tree.
